### PR TITLE
Add timestamps to broker classification schema

### DIFF
--- a/Examples/plasticc_schema/lsst.v4_1.brokerClassification.avsc
+++ b/Examples/plasticc_schema/lsst.v4_1.brokerClassification.avsc
@@ -6,6 +6,14 @@
   "fields": [
     {"name": "alertId", "type": "long", "doc": "unique alert identifer"},
     {"name": "diaObjectId", "type": "long", "doc": "unique object identifer"},
+    {"name": "elasticcPublishTimestamp",
+        "type": {"type": "long", "logicalType": "timestamp-micros"},
+        "doc": "timestamp from originating ELAsTiCC alert"
+    },
+    {"name": "brokerIngestTimestamp",
+        "type": ["null", {"type": "long", "logicalType": "timestamp-micros"}],
+        "doc": "timestamp of broker ingestion of ELAsTiCC alert"
+    },
     {"name": "classifications", "type": {
         "type": "array",
         "items": {


### PR DESCRIPTION
@gnarayan  

Adds 2 timestamps to the broker classification schema:
- `elasticcPublishTimestamp` (required)
- `brokerIngestTimestamp` (optional)

This was proposed in the LSSTC Slack channel #desc-alerts-topical-team. Copying the post here for reference:

> There is a proposed change to require brokers to submit the timestamp from the originating ELAsTiCC alert, along with their classifications. Previously this was optional. Requiring it would allow calculation of a timing metric conveniently, using only data from the broker’s message (pointed out by @agkim). If we do this, I think the requirement should be formalized up front, in the Avro schema for the broker message, so there’s no chance of it being left out.
> 
> Timestamp overview, for reference:
> 1 and 4 will provide the baseline metric DESC is interested in.
> 2 and 3 can provide brokers with additional information.
> 1. Publish time of the originating ELAsTiCC alert: Required from brokers. Required field in the broker Avro schema.
> 2. Ingestion time of ELAsTiCC alert into the broker: Optional from brokers. Optional field in the broker Avro schema.
> 3. Publish time of the broker’s classification message: Optional from brokers.  Since this timestamp is generated after the message has been serialized, it  doesn’t make sense to put it in the broker Avro schema. To submit it, brokers would provide it to the parser separately when they write their tom_desc listener.
> 4. Ingestion time of broker classification message into DESC: Automatically added when the classification is saved to DESC’s database.
> 
> Please let me know if there are any objections/suggestions.